### PR TITLE
feat: add command to publish multiple packages and update manifests automatically

### DIFF
--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -1,66 +1,67 @@
 {
-    "private": false,
-    "version": "0.0.13",
-    "name": "@polymedia/zui",
-    "author": "@juzybits (https://polymedia.app)",
-    "homepage": "https://github.com/juzybits/polymedia-zui",
-    "description": "zui: Sui command line tools",
-    "license": "Apache-2.0",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/juzybits/polymedia-zui"
-    },
-    "keywords": [
-        "polymedia",
-        "sui",
-        "cli",
-        "zui"
-    ],
-    "scripts": {
-        "build": "tsc --build",
-        "clean": "rm -rf dist/ node_modules/ .turbo/",
-        "dev": "tsc --watch --preserveWatchOutput",
-        "lint": "eslint src/ --report-unused-disable-directives --max-warnings 0",
-        "prepublishOnly": "pnpm clean && pnpm i && pnpm build && cp ../../LICENSE ../../README.md .",
-        "postpublish": "rm -f LICENSE README.md",
-        "typecheck": "tsc --noEmit",
-        "zui": "tsx src/zui.ts"
-    },
-    "dependencies": {
-        "@mysten/bcs": "^1.3.0",
-        "@mysten/move-bytecode-template": "^0.1.0",
-        "@mysten/sui": "^1.21.1",
-        "@polymedia/suitcase-core": "^0.0.44",
-        "@polymedia/suitcase-node": "^0.0.44",
-        "commander": "^13.1.0",
-        "dotenv": "^16.4.7"
-    },
-    "devDependencies": {
-        "@eslint/js": "^9.19.0",
-        "@stylistic/eslint-plugin": "^3.0.1",
-        "@types/node": "^22.13.1",
-        "eslint": "^9.19.0",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-unused-imports": "^4.1.4",
-        "tsx": "^4.19.2",
-        "typescript": "^5.7.3",
-        "typescript-eslint": "^8.23.0"
-    },
-    "type": "module",
-    "sideEffects": false,
-    "engines": {
-        "node": ">=18"
-    },
-    "packageManager": "pnpm@9.15.4",
-    "publishConfig": {
-        "access": "public"
-    },
-    "files": [
-        "dist/",
-        "LICENSE",
-        "README.md"
-    ],
-    "bin": {
-        "zui": "dist/zui.js"
-    }
+  "private": false,
+  "version": "0.0.13",
+  "name": "@polymedia/zui",
+  "author": "@juzybits (https://polymedia.app)",
+  "homepage": "https://github.com/juzybits/polymedia-zui",
+  "description": "zui: Sui command line tools",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/juzybits/polymedia-zui"
+  },
+  "keywords": [
+    "polymedia",
+    "sui",
+    "cli",
+    "zui"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist/ node_modules/ .turbo/",
+    "dev": "tsc --watch --preserveWatchOutput",
+    "lint": "eslint src/ --report-unused-disable-directives --max-warnings 0",
+    "prepublishOnly": "pnpm clean && pnpm i && pnpm build && cp ../../LICENSE ../../README.md .",
+    "postpublish": "rm -f LICENSE README.md",
+    "typecheck": "tsc --noEmit",
+    "zui": "tsx src/zui.ts"
+  },
+  "dependencies": {
+    "@iarna/toml": "^2.2.5",
+    "@mysten/bcs": "^1.3.0",
+    "@mysten/move-bytecode-template": "^0.1.0",
+    "@mysten/sui": "^1.21.1",
+    "@polymedia/suitcase-core": "^0.0.44",
+    "@polymedia/suitcase-node": "^0.0.44",
+    "commander": "^13.1.0",
+    "dotenv": "^16.4.7"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.19.0",
+    "@stylistic/eslint-plugin": "^3.0.1",
+    "@types/node": "^22.13.1",
+    "eslint": "^9.19.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-unused-imports": "^4.1.4",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.23.0"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@9.15.4",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
+  "bin": {
+    "zui": "dist/zui.js"
+  }
 }

--- a/src/cli/src/commands/publish-packages.ts
+++ b/src/cli/src/commands/publish-packages.ts
@@ -1,0 +1,283 @@
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as readline from "readline";
+
+import * as TOML from "@iarna/toml";
+import { SuiObjectChange } from "@mysten/sui/client";
+
+import { setupSuiTransaction } from "@polymedia/suitcase-node";
+
+import { log, error } from "../logger.js";
+
+/// Package name must be in PascalCase and named address must be in snake_case in Move.toml
+/// Example: name = "AccountExtensions" -> "account_extensions" = "0x0"
+
+type Package = {
+    name: string;
+    path: string;
+    dependencies: string[];
+    published?: boolean;
+};
+
+export class PackagePublisher {
+    private readonly packages: Map<string, Package>;
+
+    constructor() {
+        this.packages = new Map();
+    }
+
+    private async confirmPublish(): Promise<boolean> {
+        const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
+
+        return new Promise<boolean>((resolve) => {
+            log("\x1b[33m\nWARNING: Publishing packages will delete Move.lock files and previously published data will be lost.\x1b[0m");
+            rl.question("Are you sure you want to continue? (y/n): ", (answer: string) => {
+                rl.close();
+                resolve(answer.toLowerCase() === "y");
+            });
+        });
+    }
+
+    private findMoveTomls(dir: string): string[] {
+        const results: string[] = [];
+        const items = fs.readdirSync(dir, { withFileTypes: true });
+
+        for (const item of items) {
+            const fullPath = path.join(dir, item.name);
+            if (item.isDirectory()) {
+                results.push(...this.findMoveTomls(fullPath));
+            } else if (item.name === "Move.toml") {
+                results.push(fullPath);
+            }
+        }
+
+        return results;
+    }
+
+    public loadPackages(packagesRoot: string) {
+        const moveTomlPaths = this.findMoveTomls(packagesRoot);
+
+        for (const moveTomlPath of moveTomlPaths) {
+            const content = fs.readFileSync(moveTomlPath, "utf8");
+            const parsed = TOML.parse(content);
+
+            if (!(parsed.package as any).name) continue;
+
+            const dependencies: string[] = [];
+            if (parsed.dependencies) {
+                for (const [depName, depInfo] of Object.entries(parsed.dependencies)) {
+                    if (typeof depInfo === "object" && "local" in depInfo) {
+                        dependencies.push(depName);
+                    }
+                }
+            }
+            this.packages.set((parsed.package as any).name, {
+                name: (parsed.package as any).name,
+                path: path.dirname(moveTomlPath),
+                dependencies,
+                published: false
+            });
+        }
+    }
+
+    private getPublishOrder(): string[] {
+        const visited = new Set<string>();
+        const order: string[] = [];
+
+        const visit = (packageName: string) => {
+            if (visited.has(packageName)) return;
+            visited.add(packageName);
+
+            const pkg = this.packages.get(packageName);
+            if (!pkg) return;
+
+            for (const dep of pkg.dependencies) {
+                visit(dep);
+            }
+            order.push(packageName);
+        };
+
+        for (const packageName of this.packages.keys()) {
+            visit(packageName);
+        }
+
+        return order;
+    }
+
+    private executeSuiCommand(args: string[], options: { captureOutput?: boolean } = {}): string {
+        const buildCmd = ["sui", ...args];
+
+        const result = spawnSync(buildCmd[0], buildCmd.slice(1), {
+            stdio: options.captureOutput ? ["ignore", "pipe", "pipe"] : "inherit",
+            encoding: "utf8"
+        });
+
+        if (result.status !== 0) {
+            error("Sui command failed with status", result.status);
+            if (result.stderr) error(result.stderr);
+            process.exit(1);
+        }
+
+        return options.captureOutput ? result.stdout : "";
+    }
+
+    private async publishPackage(packageInfo: Package, createdObjDir?: string): Promise<string> {
+        log(`\n📦 Publishing package: ${packageInfo.name}`);
+
+        // Delete Move.lock
+        const moveLockPath = path.join(packageInfo.path, "Move.lock");
+        if (fs.existsSync(moveLockPath)) {
+            fs.unlinkSync(moveLockPath);
+            log("Deleted Move.lock file");
+        }
+
+        // Update Move.toml
+        const moveTomlPath = path.join(packageInfo.path, "Move.toml");
+        const namedAddress = packageInfo.name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+
+        const moveTomlContent = fs.readFileSync(moveTomlPath, "utf8");
+        const parsedToml = TOML.parse(moveTomlContent);
+
+        if (!parsedToml.addresses) {
+            error(`${packageInfo.name} Move.toml does not contain addresses section`);
+            process.exit(1);
+        }
+        // change named address to 0x0 before publish
+        (parsedToml.addresses as any)[namedAddress] = "0x0";
+        fs.writeFileSync(moveTomlPath, TOML.stringify(parsedToml));
+
+        // Build package
+        log("Building package...");
+        const buildOutput = this.executeSuiCommand(
+            ["move", "build", "--dump-bytecode-as-base64", "--path", packageInfo.path],
+            { captureOutput: true }
+        );
+        const { modules, dependencies } = JSON.parse(buildOutput);
+        // load network and signer from environment
+        const { network, client, tx, signer } = await setupSuiTransaction();
+        const sender = signer.toSuiAddress();
+        log("Active network", network);
+        log("Active address", sender);
+        
+        // Publish package
+        log("Publishing...");
+        const [upgradeCap] = tx.publish({ modules, dependencies });
+        tx.transferObjects([upgradeCap], sender);
+
+        const result = await client.signAndExecuteTransaction({
+            signer,
+            transaction: tx,
+            options: {
+                showObjectChanges: true,
+                showEffects: true,
+            },
+            requestType: "WaitForLocalExecution"
+        });
+
+        if (result.effects?.status?.status !== "success") {
+            error(`Publish failed: ${result.effects?.status?.error}`);
+            process.exit(1);
+        }
+
+        const packageId = result.objectChanges?.find((item: SuiObjectChange) => item.type === "published")?.packageId;
+
+        if (!packageId) {
+            error("Could not find package ID in publish result");
+            process.exit(1);
+        }
+
+        // Save publish info
+        const objects = result.objectChanges!.map((item: SuiObjectChange) => ({
+            type: item.type === "published" ? packageInfo.name : item.objectType,
+            id: item.type === "published" ? item.packageId : item.objectId
+        }));
+
+        if (createdObjDir) {
+            if (!fs.existsSync(createdObjDir)) {
+                fs.mkdirSync(createdObjDir, { recursive: true });
+            }
+            fs.writeFileSync(
+                `${createdObjDir}/${namedAddress.replace("_", "-")}.json`,
+                JSON.stringify(objects, null, 2)
+            );
+            log(`Created objects saved to ${createdObjDir}/${namedAddress.replace("_", "-")}.json`);
+        };
+
+        // Update Move.lock
+        this.executeSuiCommand([
+            "move", "manage-package",
+            "--environment", this.executeSuiCommand(["client", "active-env"], { captureOutput: true }).trim(),
+            "--network-id", this.executeSuiCommand(["client", "chain-identifier"], { captureOutput: true }).trim(),
+            "--original-id", packageId,
+            "--latest-id", packageId,
+            "--version-number", "1",
+            "--path", packageInfo.path
+        ]);
+
+        // Update Move.toml files (both the package itself and its dependents)
+        for (const pkg of this.packages.values()) {
+            // Skip if it's not the package itself and doesn't depend on it
+            if (pkg.name !== packageInfo.name && !pkg.dependencies.includes(packageInfo.name)) {
+                continue;
+            }
+
+            const pkgMoveToml = path.join(pkg.path, "Move.toml");
+            const content = fs.readFileSync(pkgMoveToml, "utf8");
+            const parsed = TOML.parse(content);
+
+            if (parsed.addresses && typeof parsed.addresses === "object") {
+                (parsed.addresses as Record<string, string>)[namedAddress] = packageId;
+                fs.writeFileSync(pkgMoveToml, TOML.stringify(parsed));
+                log(`Updated ${pkg.name}'s Move.toml with ${packageInfo.name}'s address`);
+            }
+        }
+
+        log("\x1b[32m" + `\n✅ Successfully published ${packageInfo.name} at: ${packageId}` + "\x1b[0m");
+        return packageId;
+    }
+
+    public async publishAll(createdObjDir?: string): Promise<boolean> {
+        if (this.packages.size === 0) {
+            log("Packages not loaded");
+            return false;
+        }
+
+        const confirmed = await this.confirmPublish();
+        if (!confirmed) {
+            log("Publish cancelled");
+            return false;
+        }
+
+        const order = this.getPublishOrder();
+        log("\n📋 Publish order:", order.join(" → "));
+
+        for (const packageName of order) {
+            const pkg = this.packages.get(packageName)!;
+            try {
+                await this.publishPackage(pkg, createdObjDir);
+                pkg.published = true;
+            } catch (error) {
+                console.error(`\n❌ Failed to publish ${packageName}:`, error);
+                break;
+            }
+        }
+
+        const successful = Array.from(this.packages.values()).filter(p => p.published).map(p => p.name);
+        const failed = Array.from(this.packages.values()).filter(p => !p.published).map(p => p.name);
+
+        log("\n📊 Publish Summary:");
+        if (successful.length > 0) {
+            log("✅ Successfully published:", successful.join(", "));
+        }
+        if (failed.length > 0) {
+            log("❌ Failed to publish:", failed.join(", "));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/cli/src/zui.ts
+++ b/src/cli/src/zui.ts
@@ -22,11 +22,12 @@ import { findNftVerified } from "./commands/find-nft-verified.js";
 import { findNfts } from "./commands/find-nfts.js";
 import { msgSign } from "./commands/msg-sign.js";
 import { msgVerify } from "./commands/msg-verify.js";
+import { PackagePublisher } from "./commands/publish-packages.js";
 import { randAddr } from "./commands/rand-addr.js";
 import "./types.js";
 
 // @ts-expect-error Property 'toJSON' does not exist on type 'BigInt'
-BigInt.prototype.toJSON = function() { return this.toString(); };
+BigInt.prototype.toJSON = function () { return this.toString(); };
 
 dotenv.config();
 
@@ -275,6 +276,17 @@ Example:
     });
 
 program
+    .command("publish")
+    .description("Publish all packages in the current or specified directory then update Move.toml and Move.lock files accordingly, optionally save the created objects' data")
+    .option("-p, --path <path>", "The path to the directory containing the packages")
+    .option("-d, --created-objects-dir <path>", "The directory where to save the created objects' types and IDs")
+    .action(async (opts) => {
+        const packageManager = new PackagePublisher();
+        packageManager.loadPackages(opts.path ?? process.cwd());
+        await packageManager.publishAll(opts.createdObjectsDir);
+    });
+
+program
     .command("rand-addr")
     .description("Generate pseudorandom Sui addresses")
     .requiredOption("-n, --number <number>", "The amount of addresses to generate")
@@ -288,8 +300,7 @@ program
 
 program.parse(process.argv);
 
-function getVersion(): string
-{
+function getVersion(): string {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 


### PR DESCRIPTION
- publish multiple packages in order, according to the dependencies
- update Move.toml and Move.lock
- update Move.toml of dependent packages
- optionally saves created objects types and ids 